### PR TITLE
auto-pr: configure `git` user

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -18,6 +18,11 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          
+      - name: Configure git
+        uses: Homebrew/actions/git-user-config@master
+        with:
+          username: BrewTestBot
 
       - run: brew update
       - run: brew install pipgrip


### PR DESCRIPTION
The `brew-pip-audit` PRs in `homebrew-core` have the `git` author and committer set to `runner`. This PR modifies the `auto-pr` workflow to use the `git-user-config` action, so the PR commits will now be authored by `BrewTestBot`.