### PR TITLE
generate-prs: better logging

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -26,6 +26,14 @@ jobs:
     timeout-minutes: 60
 
     steps:
+      - name: Display inputs
+        run: |
+          echo "AUTO_PR_DRY_RUN: ${AUTO_PR_DRY_RUN}"
+          echo "AUTO_PR_LIMIT: ${AUTO_PR_LIMIT}"
+        env:
+          AUTO_PR_DRY_RUN: ${{ inputs.dry-run }}
+          AUTO_PR_LIMIT: ${{ inputs.pr-limit }}
+
       - name: Check out this repo
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -46,5 +46,5 @@ jobs:
         run: brew ruby generate-prs.rb
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.BREW_PIP_AUDIT_GH_TOKEN }}
-          AUTO_PR_DRY_RUN: ${{ github.event.inputs.dry-run }}
-          AUTO_PR_LIMIT: ${{ github.event.inputs.pr-limit }}
+          AUTO_PR_DRY_RUN: ${{ inputs.dry-run }}
+          AUTO_PR_LIMIT: ${{ inputs.pr-limit }}

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -9,11 +9,8 @@ on:
         type: number
       dry-run:
         required: true
-        default: "true"
-        type: choice
-        options:
-          - "true"
-          - "false"
+        default: true
+        type: boolean
   workflow_run:
     workflows: ["pip-audit brew packages"]
     types: [completed]

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -54,12 +54,12 @@ for path in Dir.entries("audits").sort
 
   formula = Formula[path.delete_suffix("-requirements.audit.json")]
   if SKIP_FORMULA.include?(formula.name) || (!ONLY_FORMULA.empty? && !ONLY_FORMULA.include?(formula.name))
-    ohai "Skipping #{formula.name}"
+    ohai "#{formula.name}: skipping"
     next
   end
 
   if formula.deprecated? || formula.disabled?
-    opoo "Skipping deprecated/disabled formula: #{formula.name}"
+    opoo "#{formula.name}: skipping deprecated/disabled formula"
     next
   end
 
@@ -67,7 +67,7 @@ for path in Dir.entries("audits").sort
     r.url if vulnerable_deps.include?(PyPI.normalize_python_package r.name) && r.url =~ /files\.pythonhosted\.org/
   end.compact
 
-  ohai "vulnerable dist URLs: #{old_resource_urls.join(", ")}"
+  ohai "#{formula_name}: vulnerable dist URLs: #{old_resource_urls.join(", ")}"
 
   # HACK: Clean up the last step's update.
   formula.path.parent.cd do
@@ -81,7 +81,7 @@ for path in Dir.entries("audits").sort
     PyPI.update_python_resources!(formula,
                                   ignore_non_pypi_packages: true)
   rescue SystemExit => e
-    opoo "update_python_resources! for #{formula_name}: suppressing the previous exit and skipping"
+    opoo "#{formula_name} update_python_resources! failed: suppressing the previous exit and skipping"
     next
   end
 
@@ -93,7 +93,7 @@ for path in Dir.entries("audits").sort
     r.url if vulnerable_deps.include?(PyPI.normalize_python_package r.name) && r.url =~ /files\.pythonhosted\.org/
   end.compact
 
-  ohai "patched dist URLs: #{new_resource_urls.join(", ")}"
+  ohai "#{formula_name}: patched dist URLs: #{new_resource_urls.join(", ")}"
 
   # If we haven't changed any of the relevant resource URLs, then our resource
   # update only updated non-vulnerable dependencies.
@@ -119,7 +119,7 @@ for path in Dir.entries("audits").sort
                                             file: formula.path.relative_path_from(formula.tap.path).to_s,
                                             args: args)
   rescue SystemExit => e
-    opoo "PR dupe check for #{formula_name}: suppressing the previous exit and skipping"
+    opoo "#{formula_name} PR dupe check failed: suppressing the previous exit and skipping"
     next
   end
 

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -15,7 +15,7 @@ PR_LIMIT = ENV.fetch("AUTO_PR_LIMIT", 5).to_i
 # NOTE: The dry-run default here is the opposite of the workflow_dispatch
 # default, since the latter's default makes more sense for manually
 # triggered runs.
-DRY_RUN = !!ENV.fetch("AUTO_PR_DRY_RUN", true)
+DRY_RUN = !!ENV.fetch("AUTO_PR_DRY_RUN", false)
 
 ohai "generate-prs running with DRY_RUN=#{DRY_RUN} and PR_LIMIT=#{PR_LIMIT}"
 

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -15,7 +15,7 @@ PR_LIMIT = ENV.fetch("AUTO_PR_LIMIT", 5).to_i
 # NOTE: The dry-run default here is the opposite of the workflow_dispatch
 # default, since the latter's default makes more sense for manually
 # triggered runs.
-DRY_RUN = ENV.fetch("AUTO_PR_DRY_RUN", "false") != "true"
+DRY_RUN = ENV.fetch("AUTO_PR_DRY_RUN", "false") == "true"
 
 ohai "generate-prs running with DRY_RUN=#{DRY_RUN} and PR_LIMIT=#{PR_LIMIT}"
 

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -15,7 +15,7 @@ PR_LIMIT = ENV.fetch("AUTO_PR_LIMIT", 5).to_i
 # NOTE: The dry-run default here is the opposite of the workflow_dispatch
 # default, since the latter's default makes more sense for manually
 # triggered runs.
-DRY_RUN = !!ENV.fetch("AUTO_PR_DRY_RUN", false)
+DRY_RUN = ENV.fetch("AUTO_PR_DRY_RUN", "false") != "true"
 
 ohai "generate-prs running with DRY_RUN=#{DRY_RUN} and PR_LIMIT=#{PR_LIMIT}"
 

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -50,7 +50,7 @@ for path in Dir.entries("audits").sort
     audit.map { |dep| dep["name"] }
   end
 
-  ohai "attempting to patch deps in #{formula_name}: #{vulnerable_deps.join(", ")}"
+  ohai "#{formula_name}: attempting to patch deps: #{vulnerable_deps.join(", ")}"
 
   formula = Formula[path.delete_suffix("-requirements.audit.json")]
   if SKIP_FORMULA.include?(formula.name) || (!ONLY_FORMULA.empty? && !ONLY_FORMULA.include?(formula.name))


### PR DESCRIPTION
Disables buffered stdout to prevent confusing ordering between stdout and stderr lines; adds more context to individual logs.