### PR TITLE
Don't use --require-hashes with pip-audit

### DIFF
--- a/pip-audit-bulk
+++ b/pip-audit-bulk
@@ -35,7 +35,7 @@ assert shutil.which("pip-audit"), "missing pip-audit"
 for req in sorted(_REQUIREMENTS.glob("*.txt")):
     print(f"[+] auditing: {req.name}", file=sys.stderr)
     result = subprocess.run(
-        ["pip-audit", "--requirement", str(req), "--require-hashes", "--format=json"]
+        ["pip-audit", "--requirement", str(req), "--format=json"]
         + [f"--ignore-vuln={v}" for v in IGNORED_VULNS],
         capture_output=True,
         text=True,


### PR DESCRIPTION
require-hashes requires all dependencies to be pinned, but this isn't the case for things like six, which come from a different brew formula