### PR TITLE
generate-prs: bump revision with PRs

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -50,6 +50,9 @@ jobs:
         with:
           username: BrewTestBot
 
+      - name: Install Homebrew's bundler gems
+        run: brew ruby -e "Homebrew.install_bundler_gems!"
+
       - name: Generate Pull Requests
         run: brew ruby generate-prs.rb
         env:

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -86,9 +86,9 @@ for path in Dir.entries("audits").sort
 
   formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
   if current_revision.zero?
-    formula_ast.add_stanza(:revision, new_revision)
+    formula_ast.add_stanza(:revision, next_revision)
   else
-    formula_ast.replace_stanza(:revision, new_revision)
+    formula_ast.replace_stanza(:revision, next_revision)
   end
   formula_ast.remove_stanza(:bottle) if args.remove_bottle_block?
   formula.path.atomic_write(formula_ast.process)

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -7,9 +7,6 @@ require "utils/pypi"
 # logging below gets interleaved incorrectly.
 $stdout.sync = true
 
-# Needed for revision bumping (due to AST manipulation).
-Homebrew.install_bundler_gems!
-
 # TODO: Support grabbing these from the environment.
 ONLY_FORMULA = []
 SKIP_FORMULA = []

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -79,7 +79,21 @@ for path in Dir.entries("audits").sort
     `git reset --hard HEAD`
   end
 
-  ohai "Updating resources for #{formula.name}"
+  # Bump the formula's revision as well; adapted from `brew bump-revision`.
+  current_revision = formula.revision
+  next_revision = current_revision + 1
+  ohai "#{formula_name}: marking as revision #{next_revision}"
+
+  formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
+  if current_revision.zero?
+    formula_ast.add_stanza(:revision, new_revision)
+  else
+    formula_ast.replace_stanza(:revision, new_revision)
+  end
+  formula_ast.remove_stanza(:bottle) if args.remove_bottle_block?
+  formula.path.atomic_write(formula_ast.process)
+
+  ohai "#{formula.name}: updating Python resources"
   # TODO: Updating Python resources automatically can fail for myriad reasons;
   # we should try and handle some of them.
   begin
@@ -113,20 +127,6 @@ for path in Dir.entries("audits").sort
   else
     ohai "#{formula_name}: patched: #{vulns_patched.join(", ")}"
   end
-
-  # Bump the formula's revision as well; adapted from `brew bump-revision`.
-  current_revision = formula.revision
-  next_revision = current_revision + 1
-  ohai "#{formula_name}: marking as revision #{next_revision}"
-
-  formula_ast = Utils::AST::FormulaAST.new(formula.path.read)
-  if current_revision.zero?
-    formula_ast.add_stanza(:revision, new_revision)
-  else
-    formula_ast.replace_stanza(:revision, new_revision)
-  end
-  formula_ast.remove_stanza(:bottle) if args.remove_bottle_block?
-  formula.path.atomic_write(formula_ast.process)
 
   if DRY_RUN
     ohai "#{formula_name}: not issuing PR due to dry run"

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -90,7 +90,7 @@ for path in Dir.entries("audits").sort
   else
     formula_ast.replace_stanza(:revision, next_revision)
   end
-  formula_ast.remove_stanza(:bottle) if args.remove_bottle_block?
+  formula_ast.remove_stanza(:bottle)
   formula.path.atomic_write(formula_ast.process)
 
   ohai "#{formula.name}: updating Python resources"

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -7,6 +7,9 @@ require "utils/pypi"
 # logging below gets interleaved incorrectly.
 $stdout.sync = true
 
+# Needed for revision bumping (due to AST manipulation).
+Homebrew.install_bundler_gems!
+
 # TODO: Support grabbing these from the environment.
 ONLY_FORMULA = []
 SKIP_FORMULA = []


### PR DESCRIPTION
This ensures that these patches land with users on the formula's current version, not the next time they upgrade.

Closes #19.