### PR TITLE
generate-prs: remove theharvester from `SKIP_FORMULA`

### DIFF
--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -28,8 +28,6 @@ SKIP_FORMULA = [
   "recon-ng",
   # update_python_resources! doesn't handle git root resources
   "snapcraft",
-  # https://github.com/Homebrew/homebrew-core/blob/master/Formula/theharvester.rb#L33-L38
-  "theharvester",
   # Installable packages are in a sub-directory
   "azure-cli",
 ]


### PR DESCRIPTION
I helped the `theharvester` correctly define their dependencies in https://github.com/laramies/theHarvester/pull/1505, so after https://github.com/Homebrew/homebrew-core/pull/157756 this is no longer a special case that needs to be skipped
