### PR TITLE
generate-prs: remove fixed formulae from `SKIP_FORMULA`

### DIFF
--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -10,12 +10,6 @@ $stdout.sync = true
 # TODO: Support grabbing these from the environment.
 ONLY_FORMULA = []
 SKIP_FORMULA = [
-  # Requires setuptools pin to be removed:
-  # https://opendev.org/jjb/jenkins-job-builder/src/branch/master/requirements.txt#L4
-  "jenkins-job-builder",
-  # PRs don't work due to a bug where we use pre-release dependencies
-  # https://gitlab.com/fdroid/fdroidserver/-/merge_requests/1379
-  "fdroidserver",
   # Has a weird PyInstaller-based install that `pip` can't handle
   # https://github.com/Homebrew/homebrew-core/blob/5eb7ab4f78c012514871011fd1ab80fb0911809f/Formula/gyb.rb#L151-L160
   "gyb",


### PR DESCRIPTION
Noticed these are fixed.

`jenkins-job-builder`: The pin for `setuptools` was removed in https://opendev.org/jjb/jenkins-job-builder/commit/67645a46ebaf29d0447049d8b40f39fef31bfb70

`fdroidserver`: @alex's PR was merged and both `pipgrip` and `brew update-python-resources` point to v4.0.2 of `androguard`.