### PR TITLE
generate-prs: add option to push to main repo directly

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -72,6 +72,7 @@ jobs:
         env:
           HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.BREW_PIP_AUDIT_GH_TOKEN }}
           HOMEBREW_AUTO_PR_DRY_RUN: ${{ inputs.dry-run }}
+          HOMEBREW_AUTO_PR_NO_FORK: true
           HOMEBREW_AUTO_PR_LIMIT: ${{ inputs.pr-limit }}
           HOMEBREW_NO_INSTALL_FROM_API: 1
           HOMEBREW_EVAL_ALL: 1

--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -31,6 +31,8 @@ PR_LIMIT = ENV.fetch("HOMEBREW_AUTO_PR_LIMIT", 25).to_i
 # triggered runs.
 DRY_RUN = ENV.fetch("HOMEBREW_AUTO_PR_DRY_RUN", "false") == "true"
 
+NO_FORK = ENV.fetch("HOMEBREW_AUTO_PR_NO_FORK", "false") == "true"
+
 SUMMARY_PATH = ENV.fetch("GITHUB_STEP_SUMMARY", nil)
 
 ohai "generate-prs running with DRY_RUN=#{DRY_RUN}, PR_LIMIT=#{PR_LIMIT}, SUMMARY_PATH=#{SUMMARY_PATH}"
@@ -170,7 +172,7 @@ for path in Dir.entries("audits").sort
     tap:              formula.tap,
     pr_message:       PR_MESSAGE % {old_urls: old_resource_urls.join("\n"), new_urls: vulns_patched.join("\n")},
   }
-  GitHub.create_bump_pr(info, args: OpenStruct.new)
+  GitHub.create_bump_pr(info, args: OpenStruct.new(:no_fork? => NO_FORK))
   prs_sent += 1
   results.push({formula: formula_name, updated: true, reason: ""})
   if prs_sent == PR_LIMIT


### PR DESCRIPTION
We recently started pushing branches to the main repos; let's try this in `brew-pip-audit` too.