### PR TITLE
auto-pr: double the timeout

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   auto-pr:
     runs-on: macos-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     if: github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
 
     steps:


### PR DESCRIPTION
`pytorch` is causing a CI timeout, almost certainly because of a chonky sdist build. This attempts to ignore the problem of terrible build times by increasing our timeout to an even more unreasonable number.

If it still times out with this, I'll revert and put `pytorch` on the ignore list instead.

