### PR TITLE
dependabot: disable pip.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,10 +40,3 @@ updates:
       interval: daily
     allow:
       - dependency-type: all
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
-    allow:
-      - dependency-type: all


### PR DESCRIPTION
This is not desirable because it updates files it shouldn't.