### PR TITLE
generate-prs: skip pytorch

### DIFF
--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -22,6 +22,8 @@ SKIP_FORMULA = [
   "azure-cli",
   # source tarball doesn't work with this, due to setuptools_scm issues
   "charmcraft",
+  # Hopelessly complicated build
+  "pytorch",
 ]
 
 PR_LIMIT = ENV.fetch("HOMEBREW_AUTO_PR_LIMIT", 25).to_i


### PR DESCRIPTION
The pytorch sdist build takes up a significant portion of our PR generation run time while trying to build an absolute beast of a C++ monolith from source and finally failing with some kind of `git` error ([link](https://github.com/Homebrew/brew-pip-audit/actions/runs/9926463368/job/27420096899#step:10:8149)).

Current hypothesis is that this is their own homegrown version of the `setuptools_scm` archive problem, meaning that we can't easily address it using the GitHub release artifact.

