### PR TITLE
workflows: fix zizmor issues

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -16,6 +16,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # credentials intentionally persisted for git operations below
+          persist-credentials: true
 
       - uses: actions/setup-python@v5
         with:
@@ -51,3 +53,8 @@ jobs:
           timestamp=$(date -u)
           git commit -m "Latest data: ${timestamp}" || exit 0
           git push
+
+  auto-pr:
+    needs: [audit]
+    uses: ./.github/workflows/auto-pr.yml
+    secrets: inherit

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -5,15 +5,20 @@ on:
     inputs:
       pr-limit:
         required: true
-        default: "5"
+        default: 5
         type: number
       dry-run:
         required: true
         default: true
         type: boolean
-  workflow_run:
-    workflows: ["pip-audit brew packages"]
-    types: [completed]
+  workflow_call:
+    inputs:
+      pr-limit:
+        default: 5
+        type: number
+      dry-run:
+        default: false # don't dry-run by default when called from another workflow
+        type: boolean
 
 jobs:
   auto-pr:
@@ -34,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
In particular, this replaces `auto-pr`'s `workflow_run` with a `workflow_call`, turning it into a reusable workflow. 