### PR TITLE
feat: pin workflow action sha

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install tools
         run: brew install actionlint shellcheck zizmor
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           persist-credentials: false
 
@@ -50,7 +50,7 @@ jobs:
           zizmor --format sarif . > results.sarif || true
 
       - name: Upload SARIF file
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         with:
           name: results.sarif
           path: results.sarif
@@ -74,13 +74,13 @@ jobs:
       security-events: write
     steps:
       - name: Download SARIF file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4
         with:
           name: results.sarif
           path: results.sarif
 
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@35d3f2d6f62ccd9c6d2a51979d4284031a600c09 # v3
         with:
           sarif_file: results.sarif
           category: zizmor

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,13 +13,13 @@ jobs:
       contents: write
     steps:
       - name: Check out this repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           # credentials intentionally persisted for git operations below
           persist-credentials: true
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5
         with:
           python-version: "3.x"
 

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -35,7 +35,7 @@ jobs:
           AUTO_PR_LIMIT: ${{ inputs.pr-limit }}
 
       - name: Check out this repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -50,7 +50,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v4
+        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}


### PR DESCRIPTION
This is consistent with what we are doing with https://github.com/Homebrew/brew/pull/17691

> Pin the version of the actions to full length commit SHA as described in the [security hardening for GitHub Actions guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).