### PR TITLE
workflows: ensure auto-pr always runs on the right commit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       # NOTE: Needed to push to the repository.
       contents: write
+    outputs:
+      auto-pr-ref: ${{ steps.commit.auto-pr-ref }}
     steps:
       - name: Check out this repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -46,15 +48,22 @@ jobs:
       - run: python3 pip-audit-bulk
 
       - name: Commit and push if it changed
+        id: commit
         run: |-
           git config user.name "github.actions"
           git config user.email "actions@users.noreply.github.com"
           git add -A
           timestamp=$(date -u)
           git commit -m "Latest data: ${timestamp}" || exit 0
+          echo "auto-pr-ref=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
           git push
 
   auto-pr:
     needs: [audit]
     uses: ./.github/workflows/auto-pr.yml
     secrets: inherit
+    with:
+      # NOTE: Without this, the reusable workflow will checkout
+      # the GITHUB_REF from the caller workflow, i.e. the commit
+      # right before our push above.
+      ref: ${{ needs.audit.outputs.auto-pr-ref }}

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -11,6 +11,10 @@ on:
         required: true
         default: true
         type: boolean
+      ref:
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       pr-limit:
@@ -19,6 +23,9 @@ on:
       dry-run:
         default: false # don't dry-run by default when called from another workflow
         type: boolean
+      ref:
+        default: ${{ github.ref }}
+        type: string
 
 jobs:
   auto-pr:
@@ -39,6 +46,8 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+          # will expand to '' when unset in workflow_dispatch, i.e. default branch
+          ref: ${{ inputs.ref }}
 
       - name: Set up Homebrew
         id: set-up-homebrew


### PR DESCRIPTION
This fixes a piece of lagged state between `audit.yml` and `auto-pr.yml`: now that `auto-pr.yml` is a reusable workflow, it runs on the `GITHUB_REF` that `audit.yml` is triggered on by default.

This means that it misses the most recent `git push` containing updated vulnerability information, which in turn meant that the intended PR step always ran one cycle behind the audit step.

This PR fixes the behavior by adding a `ref:` input that feeds into `actions/checkout`, ensuring that we check out the just-pushed change. 