### PR TITLE
refactor: move to a pages-based setup

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,10 +9,12 @@ jobs:
   audit:
     runs-on: macos-latest
     permissions:
-      # NOTE: Needed to push to the repository.
-      contents: write
-    outputs:
-      auto-pr-ref: ${{ steps.commit.outputs.auto-pr-ref }}
+      contents: read # reading repo contents
+      pages: write # writing to GitHub Pages
+      id-token: write # authentication for GitHub Pages
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Check out this repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -57,21 +59,21 @@ jobs:
 
       - run: python3 pip-audit-bulk
 
-      - name: Commit and push if it changed
-        id: commit
-        run: |-
-          git add -A
-          timestamp=$(date -u)
-          git commit -m "Latest data: ${timestamp}" || exit 0
-          echo "auto-pr-ref=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
-          git push
+      - name: Setup Pages
+        if: github.repository_owner == 'Homebrew'
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: site
+
+      - name: Deploy to GitHub Pages
+        if: github.repository_owner == 'Homebrew'
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   auto-pr:
     needs: [audit]
     uses: ./.github/workflows/auto-pr.yml
     secrets: inherit
-    with:
-      # NOTE: Without this, the reusable workflow will checkout
-      # the GITHUB_REF from the caller workflow, i.e. the commit
-      # right before our push above.
-      ref: ${{ needs.audit.outputs.auto-pr-ref }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Setup Pages
         if: github.repository_owner == 'Homebrew'
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        with:
+          token: ${{ secrets.BREW_PIP_AUDIT_GH_TOKEN }}
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -62,9 +62,6 @@ jobs:
       - name: Setup Pages
         if: github.repository_owner == 'Homebrew'
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
-        with:
-          token: ${{ secrets.BREW_PIP_AUDIT_GH_TOKEN }}
-          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# CI-generated site assets
+site/*.json

--- a/pip-audit-bulk
+++ b/pip-audit-bulk
@@ -9,57 +9,66 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 # This entire script is path-sensitive.
 _HERE = Path(__file__).resolve().parent
+_SITE = _HERE / "site"
 
-_REQUIREMENTS = _HERE / "requirements"
-assert _REQUIREMENTS.is_dir(), "missing requirements to audit (wrong dir?)"
+assert _SITE.is_dir(), "missing site dir (wrong dir?)"
 
-_OUT = _HERE / "audits"
-_OUT.mkdir(exist_ok=True)
+# formula-name -> [requirements]
+_REQUIREMENTS_JSON = _SITE / "formula-requirements.json"
 
-_FAILURES = _HERE / "failures"
-_FAILURES.unlink(missing_ok=True)
+_REQUIREMENTS = json.loads(_REQUIREMENTS_JSON.read_text())
 
-_SKIPPED = _HERE / "skipped"
-_SKIPPED.unlink(missing_ok=True)
+_AUDITS_JSON = _SITE / "formula-audits.json"
 
-_SUMMARY = Path(os.environ["GITHUB_STEP_SUMMARY"])
+audits = {
+    "vulnerable": {},
+    "failures": [],
+    "skipped": [],
+}
+
+if "CI" in os.environ:
+    _SUMMARY = Path(os.environ["GITHUB_STEP_SUMMARY"])
+else:
+    _SUMMARY = None
+
 # {(dependency, CVE): [list of formula]}
 _SUMMARY_RESULTS = collections.defaultdict(list)
 
 assert shutil.which("osv-scanner"), "missing osv-scanner"
 
-# First pass: actually run the audits.
-for req in sorted(_REQUIREMENTS.glob("*.txt")):
-    print(f"[+] auditing: {req.name}", file=sys.stderr)
-    result = subprocess.run(
-        [
-            "osv-scanner",
-            "--lockfile",
-            f"requirements.txt:{req}",
-            "--format=json",
-            "--config=osv-scanner-config.toml",
-        ],
-        capture_output=True,
-        text=True,
-    )
+for formula, requirements in _REQUIREMENTS.items():
+    # osv-scanner wants a requirements.txt file, so we make a temporary one.
+    with NamedTemporaryFile(mode="w") as req_file:
+        req_file.write("\n".join(requirements))
+        req_file.flush()
 
-    # If we don't see anything on stdout, pip-audit probably failed.
+        result = subprocess.run(
+            [
+                "osv-scanner",
+                "--lockfile",
+                f"requirements.txt:{req_file.name}",
+                "--format=json",
+                "--config=osv-scanner-config.toml",
+            ],
+            capture_output=True,
+            text=True,
+        )
+
+    # If we don't see anything on stdout, osv-scanner probably failed.
     # Log it as an error.
     if not result.stdout:
-        print(f"\t>:( pip-audit failed: {result.stderr}")
-        with _FAILURES.open(mode="at") as failures:
-            print(req.name, file=failures)
+        print(f"\t>:( osv-scanner failed: {result.stderr}")
+        audits["failures"].append(formula)
         continue
 
-    # Reduce the audit to only dependencies that include vulnerabilities
     audit = json.loads(result.stdout)
     results = audit["results"]
 
     # If we're left with anything, dump it as a result.
-    out = _OUT / req.with_suffix(".audit.json").name
     if results:
         assert len(results) == 1
         vulnerable_packages = results[0]["packages"]
@@ -67,28 +76,14 @@ for req in sorted(_REQUIREMENTS.glob("*.txt")):
         for p in vulnerable_packages:
             vuln_count += len(p["groups"])
             for v in p["groups"]:
-                _SUMMARY_RESULTS[(p["package"]["name"], v["ids"][0])].append(
-                    req.name.rsplit("-", 1)[0]
-                )
-        print(
-            f"\t:-( found {vuln_count} vulnerabilities in {req.name}",
-            file=sys.stderr,
-        )
-        out.write_text(json.dumps(vulnerable_packages, indent=2))
+                _SUMMARY_RESULTS[(p["package"]["name"], v["ids"][0])].append(formula)
+        print(f"\t:-( found {vuln_count} vulnerabilities in {formula}", file=sys.stderr)
+        audits["vulnerable"][formula] = vulnerable_packages
     else:
-        out.unlink(missing_ok=True)
-        print(f"\t:-) no vulnerabilities found in {req.name}", file=sys.stderr)
+        print(f"\t:-) no vulnerabilities found in {formula}", file=sys.stderr)
 
 
-# Second pass: clean up any audits that don't have corresponding
-# requirement files, from a previous run of this script.
-# This is nasty, and should probably go somewhere else.
-for audit in _OUT.glob("*.json"):
-    req = _REQUIREMENTS / audit.with_suffix("").with_suffix(".txt").name
-    if not req.is_file():
-        print(f":-O {audit.name} orphaned ({req.name}), deleting")
-        audit.unlink()
-
+_AUDITS_JSON.write_text(json.dumps(audits, indent=2))
 
 render = """Identified the following vulnerabilities:
 
@@ -100,5 +95,6 @@ for (dep, vuln), formulas in sorted(_SUMMARY_RESULTS.items()):
     formulas_rendered = ", ".join(f"`{f}`" for f in formulas)
     render += f"| `{dep}` | [`{vuln}`](https://osv.dev/vulnerability/{vuln}) | {formulas_rendered} |\n"
 
-with _SUMMARY.open(mode="a") as io:
-    print(render, file=io)
+if _SUMMARY:
+    with _SUMMARY.open(mode="a") as io:
+        print(render, file=io)

--- a/pip-audit-bulk
+++ b/pip-audit-bulk
@@ -27,7 +27,7 @@ _AUDITS_JSON = _SITE / "formula-audits.json"
 audits = {
     "vulnerable": {},
     "failures": [],
-    "skipped": [],
+    "skipped": [],  # NOTE: currently unused
 }
 
 if "CI" in os.environ:
@@ -61,7 +61,7 @@ for formula, requirements in _REQUIREMENTS.items():
     # If we don't see anything on stdout, osv-scanner probably failed.
     # Log it as an error.
     if not result.stdout:
-        print(f"\t>:( osv-scanner failed: {result.stderr}")
+        print(f"\t>:( osv-scanner failed: {result.stderr}", file=sys.stderr)
         audits["failures"].append(formula)
         continue
 

--- a/site/index.md
+++ b/site/index.md
@@ -1,0 +1,27 @@
+---
+permalink: /
+---
+
+## What is this?
+
+This is a static GitHub Pages site for [brew-pip-audit].
+
+`brew-pip-audit` is a piece of [Homebrew]. Homebrew uses it to bulk audit
+and update Python dependencies in Homebrew formulae.
+
+[brew-pip-audit]: https://github.com/Homebrew/brew-pip-audit
+[Homebrew]: https://brew.sh
+
+## What should I do here?
+
+Nothing! This site is an implementation detail.
+
+For maintainers:
+
+* [Open brew-pip-audit PRs]
+* [Current collected requirements]
+* [Current audits]
+
+[Open brew-pip-audit PRs]: https://github.com/Homebrew/homebrew-core/pulls?q=sort%3Aupdated-desc+is%3Aopen+is%3Apr+author%3ABrewTestBot+%22bump+python+resources%22+in%3Atitle
+[Current collected requirements]: ./formula-requirements.json
+[Current audits]: ./formula-audits.json


### PR DESCRIPTION
Still a work in progress.

The basic idea here:

1. Create a stub website under `site/`
2. Update our requirements/audit generation tooling to dump JSON files under `site/`
3. Update the PR-filing tooling to read from `https://homebrew.github.io/brew-pip-audit` instead of repo state
4. ???
5. Profit

Aa part of this, the `audit.yml` workflow will also need to change to a pages-publishing workflow.

Closes #84.