### PR TITLE
Potential fix for code scanning alert no. 22: Missing regular expression anchor

### DIFF
--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -138,7 +138,7 @@ audit_json["vulnerable"].each do |formula_name, audit|
   end
 
   old_resource_urls = formula.resources.map do |r|
-    r.url if vulnerable_deps.include?(PyPI.normalize_python_package r.name) && r.url =~ /files\.pythonhosted\.org/
+    r.url if vulnerable_deps.include?(PyPI.normalize_python_package r.name) && r.url =~ /\Ahttps?:\/\/files\.pythonhosted\.org\//
   end.compact
 
   ohai "#{formula_name}: vulnerable dist URLs: #{old_resource_urls.join(", ")}"


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/brew-pip-audit/security/code-scanning/22](https://github.com/Homebrew/brew-pip-audit/security/code-scanning/22)

To fix the problem, the regular expression should be anchored so that it matches only URLs whose host is exactly "files.pythonhosted.org". In Ruby, the recommended anchors for the start and end of a string are `\A` and `\z`, not `^` and `$`, to avoid issues with newlines. The best fix is to update the regular expression in line 141 to use `\Ahttps?:\/\/files\.pythonhosted\.org\/`, which will match only URLs that start with "http://" or "https://" and then "files.pythonhosted.org/". This change should be made only in the relevant line in `generate-prs.rb`. No new imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
