### PR TITLE
Potential fix for code scanning alert no. 24: Missing regular expression anchor

### DIFF
--- a/formula2requirements.rb
+++ b/formula2requirements.rb
@@ -15,7 +15,7 @@ Formula.all.sort.each do |f|
   next unless f.tap.name == "homebrew/core"
 
   # Look for formulae that have PyPI resources; skip those that don't.
-  python_resources = f.resources.select { |r| r.url =~ /files\.pythonhosted\.org/ }
+  python_resources = f.resources.select { |r| URI.parse(r.url).host == "files.pythonhosted.org" }
   next if python_resources.empty?
 
   # Skip deprecated and disabled formulae.


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/brew-pip-audit/security/code-scanning/24](https://github.com/Homebrew/brew-pip-audit/security/code-scanning/24)

To fix the problem, the regular expression should be anchored so that it matches only URLs where "files.pythonhosted.org" appears in the correct location (the host portion). Since the code is working with URLs, the best way is to parse the URL and check the host directly, rather than matching the entire URL string with a regular expression. This avoids any ambiguity and ensures only the intended host is matched. The fix should be applied to line 18 in `formula2requirements.rb`, replacing the regular expression match with a check on the parsed host.

No new imports are needed, as `URI` is already required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
