### PR TITLE
Potential fix for code scanning alert no. 23: Missing regular expression anchor

### DIFF
--- a/generate-prs.rb
+++ b/generate-prs.rb
@@ -167,7 +167,7 @@ audit_json["vulnerable"].each do |formula_name, audit|
   formula = Formula[formula.name]
 
   new_resource_urls = formula.resources.map do |r|
-    r.url if vulnerable_deps.include?(PyPI.normalize_python_package r.name) && r.url =~ /files\.pythonhosted\.org/
+    r.url if vulnerable_deps.include?(PyPI.normalize_python_package r.name) && r.url =~ /\Ahttps?:\/\/files\.pythonhosted\.org\//
   end.compact
 
   ohai "#{formula_name}: patched dist URLs: #{new_resource_urls.join(", ")}"


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/brew-pip-audit/security/code-scanning/23](https://github.com/Homebrew/brew-pip-audit/security/code-scanning/23)

To fix the problem, the regular expression should be anchored so that it matches only when "files.pythonhosted.org" appears at the start of the host portion of the URL. In Ruby, the best way to do this is to use the `\A` anchor to match the start of the string, and to include the URL scheme and host in the pattern. For example, the pattern should match URLs that start with "http://" or "https://" followed immediately by "files.pythonhosted.org". The updated regular expression would be `/\Ahttps?:\/\/files\.pythonhosted\.org\//`. This change should be made on line 170 of `generate-prs.rb`, replacing the unanchored pattern.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
