### PR TITLE
Potential fix for code scanning alert no. 29: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -74,6 +74,7 @@ jobs:
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   auto-pr:
+    permissions: {}
     needs: [audit]
     uses: ./.github/workflows/auto-pr.yml
     secrets: inherit


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/brew-pip-audit/security/code-scanning/29](https://github.com/Homebrew/brew-pip-audit/security/code-scanning/29)

To fix the problem, add an explicit `permissions` block to the `auto-pr` job in `.github/workflows/audit.yml`. The minimal safe default is `permissions: {}` (no permissions), unless the job requires specific permissions. Since the job uses a reusable workflow (`auto-pr.yml`), and unless we know it needs more, we should start with the most restrictive setting. If the called workflow needs more, it can request them. The change should be made by inserting a `permissions: {}` line under the `auto-pr:` job definition, at the same indentation level as `needs`, `uses`, and `secrets`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
