### PR TITLE
Potential fix for code scanning alert no. 13: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -1,5 +1,9 @@
 name: Submit PRs for audit results
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/Homebrew/brew-pip-audit/security/code-scanning/13](https://github.com/Homebrew/brew-pip-audit/security/code-scanning/13)

To fix the problem, add a `permissions` block to the workflow file. The best practice is to set the most restrictive permissions at the workflow level (e.g., `contents: read`), and then escalate permissions for specific jobs if necessary. In this case, since the workflow generates pull requests, it will need `pull-requests: write` in addition to `contents: read`. The `permissions` block should be added near the top of the file, after the `name` and before the `on` block, or at the job level if only one job requires elevated permissions. Since there is only one job (`auto-pr`), it is simplest and clearest to add the `permissions` block at the workflow level, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
