### PR TITLE
workflows: remove `test-bot` Action inputs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Configure Homebrew, install dependencies
         run: |

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -62,7 +62,6 @@ jobs:
         with:
           core: true
           cask: false
-          test-bot: false
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache


### PR DESCRIPTION
`test-bot` has been merged into Homebrew/brew, so this is no longer necessary and outputs a warning in CI.

---

- https://github.com/Homebrew/brew/pull/20762